### PR TITLE
docs(readme): delete indent for TIP block

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,7 @@ The optional features can be enabled with few startup overhead thanks to
 > Optionally, you can manage your Fennel files under `lua/` instead of `fnl/`
 > directory.
 
-- ...and more features!
-
-And this project started from scratch.
+...and more features! So, this project started from scratch.
 
 ## ✔️ Requirements
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ The optional features can be enabled with few startup overhead thanks to
 - I don't like to mess up `lua/` as I still write Lua when it seems to be more
   comfortable than Fennel. (Type annotation helps us very much.)
 
-  > [!TIP]
-  > Optionally, you can manage your Fennel files under `lua/` instead of `fnl/`
-  > directory.
+> [!TIP]
+> Optionally, you can manage your Fennel files under `lua/` instead of `fnl/`
+> directory.
 
 - ...and more features!
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,9 @@ How about trying **`:Fnl (vim.tbl_extend :force {:foo :bar} {:foo :qux`**
 (_uh..., typos?_ ¯\\\_(ツ)\_/¯),\
 or `:=vim.tbl_extend("force", {foo = "bar"}, {foo = "baz"})`?
 
-[![badge/test][]][url/to/workflow/test]
-[![badge/semver][]][url/to/semver]
+[![badge/test][]][url/to/workflow/test] [![badge/semver][]][url/to/semver]
 [![badge/license][]][url/to/license]\
-[![badge/lua][]][url/to/lua]
-[![badge/fennel][]][url/to/fennel]
+[![badge/lua][]][url/to/lua] [![badge/fennel][]][url/to/fennel]
 
 <!--
 NOTE: The colors come from the palette of catppuccin-mocha:


### PR DESCRIPTION
GitHub does not seem to detect `[!TIP]` in indent block.