### PR TITLE
fix(watch): deal with loaded file buffer later removed externally

### DIFF
--- a/fnl/thyme/user/watch.fnl
+++ b/fnl/thyme/user/watch.fnl
@@ -195,10 +195,10 @@ failed."
   (each [_ dependent (pairs dependent-maps)]
     ;; TODO: Wrap `update-module-dependencies!` into
     ;; `uv.new_async`, but does it keep the consistency?
-    (when (file-readable? dependent.fnl-path)
-      (-> #(-> (Watcher.new dependent.fnl-path)
-               (: :update!))
-          (vim.schedule)))))
+    (-> #(when (file-readable? dependent.fnl-path)
+           (-> (Watcher.new dependent.fnl-path)
+               (: :update!)))
+        (vim.schedule))))
 
 (fn Watcher.new [fnl-path]
   "Create Watcher instance if available, or return nil.

--- a/fnl/thyme/user/watch.fnl
+++ b/fnl/thyme/user/watch.fnl
@@ -40,8 +40,10 @@
 (fn Watcher.get-modmap [self]
   ;; TODO: Once stable, update ._modmap on the strategies recompile and reload
   ;; for performance?
-  (case (Modmap.try-read-from-file (self:get-fnl-path))
-    latest-modmap (set self._modmap latest-modmap))
+  (let [fnl-path (self:get-fnl-path)]
+    (when (file-readable? fnl-path)
+      (case (Modmap.try-read-from-file fnl-path)
+        latest-modmap (set self._modmap latest-modmap))))
   self._modmap)
 
 (fn Watcher.get-lua-path [self]
@@ -207,10 +209,11 @@ failed."
   (assert-is-fnl-file fnl-path)
   (let [self (setmetatable {} Watcher)]
     (set self._fnl-path fnl-path)
-    (case (Modmap.try-read-from-file fnl-path)
-      modmap (do
-               (set self._modmap modmap)
-               self))))
+    (when (file-readable? fnl-path)
+      (case (Modmap.try-read-from-file fnl-path)
+        modmap (do
+                 (set self._modmap modmap)
+                 self)))))
 
 (fn watch-files! []
   "Add an autocmd in augroup named `ThymeWatch` to watch fennel files.

--- a/lua/thyme/user/watch.lua
+++ b/lua/thyme/user/watch.lua
@@ -227,14 +227,15 @@ Watcher["update!"] = function(self)
 end
 Watcher["update-dependent-modules!"] = function(dependent_maps)
   for _, dependent in pairs(dependent_maps) do
-    if file_readable_3f(dependent["fnl-path"]) then
-      local function _39_()
+    local function _39_()
+      if file_readable_3f(dependent["fnl-path"]) then
         local tgt_40_ = Watcher.new(dependent["fnl-path"])
         return (tgt_40_)["update!"](tgt_40_)
+      else
+        return nil
       end
-      vim.schedule(_39_)
-    else
     end
+    vim.schedule(_39_)
   end
   return nil
 end

--- a/lua/thyme/user/watch.lua
+++ b/lua/thyme/user/watch.lua
@@ -29,30 +29,34 @@ Watcher["get-fnl-path"] = function(self)
 end
 Watcher["get-modmap"] = function(self)
   do
-    local _8_ = Modmap["try-read-from-file"](self["get-fnl-path"](self))
-    if (nil ~= _8_) then
-      local latest_modmap = _8_
-      self._modmap = latest_modmap
+    local fnl_path = self["get-fnl-path"](self)
+    if file_readable_3f(fnl_path) then
+      local _8_ = Modmap["try-read-from-file"](fnl_path)
+      if (nil ~= _8_) then
+        local latest_modmap = _8_
+        self._modmap = latest_modmap
+      else
+      end
     else
     end
   end
   return self._modmap
 end
 Watcher["get-lua-path"] = function(self)
-  local tgt_10_ = self["get-modmap"](self)
-  return (tgt_10_)["get-lua-path"](tgt_10_)
+  local tgt_11_ = self["get-modmap"](self)
+  return (tgt_11_)["get-lua-path"](tgt_11_)
 end
 Watcher["get-module-name"] = function(self)
-  local tgt_11_ = self["get-modmap"](self)
-  return (tgt_11_)["get-module-name"](tgt_11_)
+  local tgt_12_ = self["get-modmap"](self)
+  return (tgt_12_)["get-module-name"](tgt_12_)
 end
 Watcher["get-depentent-maps"] = function(self)
-  local tgt_12_ = self["get-modmap"](self)
-  return (tgt_12_)["get-depentent-maps"](tgt_12_)
+  local tgt_13_ = self["get-modmap"](self)
+  return (tgt_13_)["get-depentent-maps"](tgt_13_)
 end
 Watcher["macro?"] = function(self)
-  local tgt_13_ = self["get-modmap"](self)
-  return (tgt_13_)["macro?"](tgt_13_)
+  local tgt_14_ = self["get-modmap"](self)
+  return (tgt_14_)["macro?"](tgt_14_)
 end
 Watcher["hide-macro-module!"] = function(self)
   local module_name = self["get-module-name"](self)
@@ -67,9 +71,9 @@ Watcher["should-update?"] = function(self)
   if modmap["macro?"](modmap) then
     return true
   else
-    local _14_ = modmap["get-lua-path"](modmap)
-    if (nil ~= _14_) then
-      local lua_path = _14_
+    local _15_ = modmap["get-lua-path"](modmap)
+    if (nil ~= _15_) then
+      local lua_path = _15_
       if file_readable_3f(lua_path) then
         local fnl_path = modmap["get-fnl-path"](modmap)
         return (read_file(lua_path) ~= compile_file(fnl_path))
@@ -77,7 +81,7 @@ Watcher["should-update?"] = function(self)
         return false
       end
     else
-      local _ = _14_
+      local _ = _15_
       return error(("invalid ModuleMap instance for %s: %s"):format(modmap["get-module-name"](modmap), vim.inspect(modmap)))
     end
   end
@@ -102,18 +106,18 @@ Watcher["try-recompile!"] = function(self)
   assert(not modmap["macro?"](modmap), "Invalid attempt to recompile macro")
   compiler_options["module-name"] = module_name
   modmap["hide!"](modmap, fnl_path)
-  local _18_, _19_ = DepObserver["observe!"](DepObserver, fennel["compile-string"], fnl_path, lua_path, compiler_options, module_name)
-  if ((_18_ == true) and (nil ~= _19_)) then
-    local lua_code = _19_
+  local _19_, _20_ = DepObserver["observe!"](DepObserver, fennel["compile-string"], fnl_path, lua_path, compiler_options, module_name)
+  if ((_19_ == true) and (nil ~= _20_)) then
+    local lua_code = _20_
     local msg = ("successfully recompiled " .. fnl_path)
     local backup_handler = RuntimeModuleRollbackManager["backup-handler-of"](RuntimeModuleRollbackManager, module_name)
     write_lua_file_with_backup_21(lua_path, lua_code, module_name)
     backup_handler["cleanup-old-backups!"](backup_handler)
     WatchMessenger["notify!"](WatchMessenger, msg)
     return true
-  elseif (true and (nil ~= _19_)) then
-    local _ = _18_
-    local error_msg = _19_
+  elseif (true and (nil ~= _20_)) then
+    local _ = _19_
+    local error_msg = _20_
     local msg = ("abort recompiling %s due to the following error:\n%s"):format(fnl_path, error_msg)
     WatchMessenger["notify!"](WatchMessenger, msg, vim.log.levels.WARN)
     package.loaded[module_name] = last_chunk
@@ -129,11 +133,11 @@ Watcher["try-reload!"] = function(self)
   local last_chunk = package.loaded[modname]
   package.loaded[modname] = nil
   if modmap["macro?"](modmap) then
-    local _21_, _22_ = pcall(require, modname)
-    if (_21_ == true) then
+    local _22_, _23_ = pcall(require, modname)
+    if (_22_ == true) then
       return WatchMessenger["notify!"](WatchMessenger, ("Successfully reloaded " .. modname))
-    elseif ((_21_ == false) and (nil ~= _22_)) then
-      local error_msg = _22_
+    elseif ((_22_ == false) and (nil ~= _23_)) then
+      local error_msg = _23_
       local msg = ("Failed to reload %s due to the following error:\n%s"):format(modname, error_msg)
       package.loaded[modname] = last_chunk
       return WatchMessenger["notify!"](WatchMessenger, msg, vim.log.levels.ERROR)
@@ -154,12 +158,12 @@ Watcher["update!"] = function(self)
   end
   local always_3f, strategy = nil, nil
   do
-    local _26_, _27_ = raw_strategy:match("^(%S-%-)(%S+)$")
-    if ((_26_ == "always-") and (nil ~= _27_)) then
-      local strategy0 = _27_
+    local _27_, _28_ = raw_strategy:match("^(%S-%-)(%S+)$")
+    if ((_27_ == "always-") and (nil ~= _28_)) then
+      local strategy0 = _28_
       always_3f, strategy = true, strategy0
     else
-      local _ = _26_
+      local _ = _27_
       always_3f, strategy = false, raw_strategy
     end
   end
@@ -227,15 +231,15 @@ Watcher["update!"] = function(self)
 end
 Watcher["update-dependent-modules!"] = function(dependent_maps)
   for _, dependent in pairs(dependent_maps) do
-    local function _39_()
+    local function _40_()
       if file_readable_3f(dependent["fnl-path"]) then
-        local tgt_40_ = Watcher.new(dependent["fnl-path"])
-        return (tgt_40_)["update!"](tgt_40_)
+        local tgt_41_ = Watcher.new(dependent["fnl-path"])
+        return (tgt_41_)["update!"](tgt_41_)
       else
         return nil
       end
     end
-    vim.schedule(_39_)
+    vim.schedule(_40_)
   end
   return nil
 end
@@ -243,11 +247,15 @@ Watcher.new = function(fnl_path)
   assert_is_fnl_file(fnl_path)
   local self = setmetatable({}, Watcher)
   self["_fnl-path"] = fnl_path
-  local _42_ = Modmap["try-read-from-file"](fnl_path)
-  if (nil ~= _42_) then
-    local modmap = _42_
-    self._modmap = modmap
-    return self
+  if file_readable_3f(fnl_path) then
+    local _43_ = Modmap["try-read-from-file"](fnl_path)
+    if (nil ~= _43_) then
+      local modmap = _43_
+      self._modmap = modmap
+      return self
+    else
+      return nil
+    end
   else
     return nil
   end
@@ -256,8 +264,8 @@ local function watch_files_21()
   local group = vim.api.nvim_create_augroup("ThymeWatch", {})
   local opts = Config.watch
   local callback
-  local function _45_(_44_)
-    local fnl_path = _44_["match"]
+  local function _47_(_46_)
+    local fnl_path = _46_["match"]
     local resolved_path = vim.fn.resolve(fnl_path)
     if (config_path == resolved_path) then
       if allowed_3f(config_path) then
@@ -270,16 +278,16 @@ local function watch_files_21()
       else
       end
     else
-      local _48_ = Watcher.new(fnl_path)
-      if (nil ~= _48_) then
-        local watcher = _48_
+      local _50_ = Watcher.new(fnl_path)
+      if (nil ~= _50_) then
+        local watcher = _50_
         watcher["update!"](watcher)
       else
       end
     end
     return nil
   end
-  callback = _45_
+  callback = _47_
   return vim.api.nvim_create_autocmd(opts.event, {group = group, pattern = opts.pattern, callback = callback})
 end
 return {["watch-files!"] = watch_files_21}

--- a/test/watch_spec.fnl
+++ b/test/watch_spec.fnl
@@ -1,0 +1,94 @@
+(import-macros {: describe* : it*} :test.helper.busted-macros)
+
+(include :test.helper.prerequisites)
+
+(local {: prepare-config-fnl-file! : remove-context-files!}
+       (include :test.helper.util))
+
+(local thyme (require :thyme))
+(local Config (require :thyme.config))
+
+(describe* "ThymeWatch"
+  (setup (fn []
+           (thyme:setup)))
+  (after_each (fn []
+                (remove-context-files!)))
+  (describe* "with strategy=always-clear-all"
+    (let [default-strategy Config.watch.strategy]
+      (before_each (fn []
+                     (set Config.watch.strategy "always-clear-all")))
+      (after_each (fn []
+                    (set Config.watch.strategy default-strategy)))
+      (describe* "should clear the cache for modified Fennel file;"
+        (let [mod "foo"
+              filename (.. mod ".fnl")]
+          (it* "thus, each `require` should return different results on BufWritePost event twice."
+            ;; NOTE: `prepare-config-fnl-file!` creates a new file per call; thus,
+            ;; it should be called in each `it` block.
+            (let [path (prepare-config-fnl-file! filename "1")]
+              (assert.equals 1 (require mod))
+              (tset package.loaded mod nil)
+              (vim.cmd.edit path)
+              (vim.api.nvim_buf_set_lines 0 0 -1 true ["2"])
+              (vim.cmd.write path)
+              (assert.equals 2 (require mod))
+              (tset package.loaded mod nil)
+              (vim.api.nvim_buf_set_lines 0 0 -1 true ["3"])
+              (vim.cmd.write path)
+              (assert.equals 3 (require mod))
+              (tset package.loaded mod nil)
+              (vim.cmd.bdelete path)
+              (vim.fn.delete path))))))))
+
+;; NOTE: It affect other tests even in `pending`.
+;; (pending (it* "however, nvim cannot detect changes by `file:write`."
+;;            (let [path (prepare-config-fnl-file! filename "1")]
+;;              (assert.equals 1 (require mod))
+;;              (tset package.loaded mod nil)
+;;              (vim.cmd.edit path)
+;;              (with-open [f (assert (io.open path "w"))]
+;;                (f:write "2"))
+;;              (vim.cmd :checktime)
+;;              (assert.equals 1 (require mod))
+;;              (tset package.loaded mod nil)
+;;              (with-open [f (assert (io.open path "w"))]
+;;                (f:write "3"))
+;;              (vim.cmd :checktime)
+;;              (assert.equals 1 (require mod))
+;;              (tset package.loaded mod nil)
+;;              (vim.cmd.bdelete path)
+;;              (vim.fn.delete path)))))))))
+
+;; (describe* "ThymeWatch on macro file"
+;;   (let [default-watch-strategy Config.watch.strategy]
+;;     (setup (fn []
+;;              (thyme:setup)))
+;;     (after_each (fn []
+;;                   (vim.cmd "% bdelete")
+;;                   (set Config.watch.strategy default-watch-strategy)
+;;                   (remove-context-files!)))
+;;     (describe* "with config.watch.macro-strategy=recompile"
+;;       (before_each (fn []
+;;                      (set Config.watch.strategy "recompile")))
+;;       (describe* "detecting changes on a macro file on BufWritePost"
+;;         (let [macro-mod "macro-mod"
+;;               macro-filename (.. macro-mod ".fnl")
+;;               dependent-mod "dependent-mod"
+;;               dependent-filename (.. dependent-mod ".fnl")]
+;;           (it* "should recompile its dependent Fennel files change on BufWritePost once."
+;;             (let [macro-path (prepare-config-fnl-file! macro-filename
+;;                                                        "{:test (fn [] 1)}")
+;;                   dependent-path (prepare-config-fnl-file! dependent-filename
+;;                                                            (-> "(import-macros {: test} :%s) (test)"
+;;                                                                (: :format
+;;                                                                   macro-mod)))]
+;;               (vim.cmd.edit macro-path)
+;;               (assert.equals 1 (require dependent-mod))
+;;               (tset package.loaded dependent-mod nil)
+;;               (vim.api.nvim_buf_set_lines 0 0 -1 true ["{:test (fn [] 2)}"])
+;;               (vim.cmd.write macro-path)
+;;               (assert.equals 2 (require dependent-mod))
+;;               (tset package.loaded dependent-mod nil)
+;;               (vim.fn.delete macro-path)
+;;               (vim.fn.delete dependent-path)
+;;               (vim.cmd.bdelete macro-path))))))))


### PR DESCRIPTION
Previously, `FileChangedShellPost` event throws errors for such externally removed buffers.