### PR TITLE
refactor(dropin): apply lazyredraw

### DIFF
--- a/fnl/thyme/user/dropin.fnl
+++ b/fnl/thyme/user/dropin.fnl
@@ -76,6 +76,7 @@ matched by `pattern`, and the rests behind, are the arguments of `replacement`.
                                                                replacement)
                           _ old-cmdline)
                         old-cmdline)
+        last-lz vim.o.lazyredraw
         last-wcm vim.o.wildcharm
         tmp-wcm "\26"
         right-keys (case (new-cmdline:find old-cmdline 1 true)
@@ -87,8 +88,10 @@ matched by `pattern`, and the rests behind, are the arguments of `replacement`.
                  (vim.keycode)
                  (.. tmp-wcm))]
     (set vim.o.wcm (vim.fn.str2nr tmp-wcm))
+    (set vim.o.lazyredraw true)
     (vim.api.nvim_feedkeys keys "ni" false)
-    (set vim.o.wcm last-wcm)))
+    (set vim.o.wcm last-wcm)
+    (set vim.o.lazyredraw last-lz)))
 
 (λ M.enable-dropin-paren! []
   "Realize dropin-paren feature.

--- a/lua/thyme/user/dropin.lua
+++ b/lua/thyme/user/dropin.lua
@@ -62,8 +62,9 @@ M.complete = function(pattern, replacement)
   else
     new_cmdline = old_cmdline
   end
+  local last_lz = vim.o.lazyredraw
   local last_wcm = vim.o.wildcharm
-  local tmp_wcm = "\26"
+  local tmp_wcm = ""
   local right_keys
   do
     local _12_ = new_cmdline:find(old_cmdline, 1, true)
@@ -78,8 +79,10 @@ M.complete = function(pattern, replacement)
   end
   local keys = (vim.keycode((("<C-BSlash>e%q<CR>"):format(new_cmdline) .. right_keys)) .. tmp_wcm)
   vim.o.wcm = vim.fn.str2nr(tmp_wcm)
+  vim.o.lazyredraw = true
   vim.api.nvim_feedkeys(keys, "ni", false)
   vim.o.wcm = last_wcm
+  vim.o.lazyredraw = last_lz
   return nil
 end
 M["enable-dropin-paren!"] = function()


### PR DESCRIPTION
GitHub does not render the unprintable `^Z`. What is the better way to implement it?