### PR TITLE
refactor(health): extract `vim.health` functions into `report`

### DIFF
--- a/fnl/thyme/health.fnl
+++ b/fnl/thyme/health.fnl
@@ -12,21 +12,21 @@
 
 (local RollbackManager (require :thyme.rollback.manager))
 
-(local (report-start report-info report-ok report-warn report-error)
-       (let [health vim.health]
-         (if health.start
-             (values health.start health.info health.ok health.warn
-                     health.error)
-             ;; For nvim <0.10.0
-             ;; (The support will be dropped w/o deprecation notice.)
-             (values health.report_start health.report_info health.report_ok
-                     health.report_warn health.report_error))))
+(local report (if vim.health.start
+                  vim.health
+                  ;; For nvim <0.10.0
+                  ;; (The support will be dropped w/o deprecation notice.)
+                  {:start vim.health.report_start
+                   :info vim.health.report_info
+                   :ok vim.health.report_ok
+                   :warn vim.health.report_warn
+                   :error vim.health.report_error}))
 
 (fn report-integrations []
-  (report-start "Thyme Integrations")
+  (report.start "Thyme Integrations")
   (let [reporter (if (= nil vim.g.parinfer_loaded)
-                     report-warn
-                     report-ok)]
+                     report.warn
+                     report.ok)]
     (reporter (-> "`%s`"
                   (: :format
                      (.. "vim.g.parinfer_loaded = "
@@ -36,42 +36,42 @@
     ;; https://github.com/nvim-treesitter/nvim-treesitter.
     (each [_ file (ipairs dependency-files)]
       (case (get-runtime-files [file] false)
-        [path] (report-ok (: "`%s` is detected at `%s`." :format file path))
-        _ (report-warn (: "missing `%s`." :format file))))))
+        [path] (report.ok (: "`%s` is detected at `%s`." :format file path))
+        _ (report.warn (: "missing `%s`." :format file))))))
 
 (fn report-thyme-disk-info []
-  (report-start "Thyme Disk Info")
-  (report-info (-> "The path to .nvim-thyme.fnl: `%s`" (: :format config-path)))
-  (report-info (-> "The root path of Lua cache:  `%s`"
+  (report.start "Thyme Disk Info")
+  (report.info (-> "The path to .nvim-thyme.fnl: `%s`" (: :format config-path)))
+  (report.info (-> "The root path of Lua cache:  `%s`"
                    (: :format lua-cache-prefix)))
-  (report-info (-> "The root path of backups for rollback: `%s`"
+  (report.info (-> "The root path of backups for rollback: `%s`"
                    (: :format (get-root-of-backup))))
-  (report-info (-> "The root path of module-mapping: `%s`"
+  (report.info (-> "The root path of module-mapping: `%s`"
                    (: :format (get-root-of-modmap))))
-  (report-info (-> "The root path of pool: `%s`"
+  (report.info (-> "The root path of pool: `%s`"
                    (: :format (get-root-of-pool)))))
 
 (fn report-thyme-config []
-  (report-start "Thyme .nvim-thyme.fnl")
+  (report.start "Thyme .nvim-thyme.fnl")
   (let [config (get-config)]
     ;; TODO: Dump the file contents in .nvim-thyme.fnl instead?
     ;; NOTE: To inject fennel syntax, `<` must be put at the head of the line,
     ;; but health does not allow it.
-    (report-info (-> "The current config:
+    (report.info (-> "The current config:
 
 %s
 "
                      (: :format (fennel.view config))))))
 
 (fn report-fennel-paths []
-  (report-start "Thyme fennel.{path,macro-path}")
-  (report-info (-> "fennel.path:\n- `%s`" ;
+  (report.start "Thyme fennel.{path,macro-path}")
+  (report.info (-> "fennel.path:\n- `%s`" ;
                    (: :format (fennel.path:gsub ";" "`\n- `"))))
-  (report-info (-> "fennel.macro-path:\n- `%s`"
+  (report.info (-> "fennel.macro-path:\n- `%s`"
                    (: :format (fennel.macro-path:gsub ";" "`\n- `")))))
 
 ;; (fn report-imported-macros []
-;;   (report-start "Thyme Imported Macros")
+;;   (report.start "Thyme Imported Macros")
 ;;   (let [root (get-root-of-modmap)
 ;;         reporter (fn [log-path]
 ;;                    (let [modmap (ModuleMap.read-log-file log-path)]
@@ -83,21 +83,21 @@
 ;;   `%s`
 ;; - dependency-map file:
 ;;   `%s`" :format module-name fnl-path log-path)]
-;;                         (report-info msg)))))]
+;;                         (report.info msg)))))]
 ;;     (each-file reporter root)))
 
 ;; TODO: Replace `.list-mounted-paths`, or just remove this check?
 ;; (fn report-mounted-paths []
-;;   (report-start "Thyme Mounted Paths")
+;;   (report.start "Thyme Mounted Paths")
 ;;   (let [mounted-paths (RollbackManager.list-mounted-paths)]
 ;;     (if (next mounted-paths)
 ;;         (do
 ;;           ;; TODO: Split reports per rollback kind: config, macro, and module
-;;           (report-info (-> "Th mounted paths:\n- `%s`"
+;;           (report.info (-> "Th mounted paths:\n- `%s`"
 ;;                            (: :format
 ;;                               (-> mounted-paths
 ;;                                   (table.concat "`\n- `"))))))
-;;         (report-info "No paths are mounted."))))
+;;         (report.info "No paths are mounted."))))
 
 {:check (fn []
           (report-integrations)

--- a/lua/thyme/health.lua
+++ b/lua/thyme/health.lua
@@ -15,23 +15,20 @@ local get_runtime_files = _local_6_["get-runtime-files"]
 local _local_7_ = require("thyme.dependency.unit")
 local get_root_of_modmap = _local_7_["get-root"]
 local RollbackManager = require("thyme.rollback.manager")
-local report_start, report_info, report_ok, report_warn, report_error = nil, nil, nil, nil, nil
-do
-  local health = vim.health
-  if health.start then
-    report_start, report_info, report_ok, report_warn, report_error = health.start, health.info, health.ok, health.warn, health.error
-  else
-    report_start, report_info, report_ok, report_warn, report_error = health.report_start, health.report_info, health.report_ok, health.report_warn, health.report_error
-  end
+local report
+if vim.health.start then
+  report = vim.health
+else
+  report = {start = vim.health.report_start, info = vim.health.report_info, ok = vim.health.report_ok, warn = vim.health.report_warn, error = vim.health.report_error}
 end
 local function report_integrations()
-  report_start("Thyme Integrations")
+  report.start("Thyme Integrations")
   do
     local reporter
     if (nil == vim.g.parinfer_loaded) then
-      reporter = report_warn
+      reporter = report.warn
     else
-      reporter = report_ok
+      reporter = report.ok
     end
     reporter(("`%s`"):format(("vim.g.parinfer_loaded = " .. tostring(vim.g.parinfer_loaded))))
   end
@@ -40,31 +37,31 @@ local function report_integrations()
     local _10_ = get_runtime_files({file}, false)
     if ((_G.type(_10_) == "table") and (nil ~= _10_[1])) then
       local path = _10_[1]
-      report_ok(("`%s` is detected at `%s`."):format(file, path))
+      report.ok(("`%s` is detected at `%s`."):format(file, path))
     else
       local _0 = _10_
-      report_warn(("missing `%s`."):format(file))
+      report.warn(("missing `%s`."):format(file))
     end
   end
   return nil
 end
 local function report_thyme_disk_info()
-  report_start("Thyme Disk Info")
-  report_info(("The path to .nvim-thyme.fnl: `%s`"):format(config_path))
-  report_info(("The root path of Lua cache:  `%s`"):format(lua_cache_prefix))
-  report_info(("The root path of backups for rollback: `%s`"):format(get_root_of_backup()))
-  report_info(("The root path of module-mapping: `%s`"):format(get_root_of_modmap()))
-  return report_info(("The root path of pool: `%s`"):format(get_root_of_pool()))
+  report.start("Thyme Disk Info")
+  report.info(("The path to .nvim-thyme.fnl: `%s`"):format(config_path))
+  report.info(("The root path of Lua cache:  `%s`"):format(lua_cache_prefix))
+  report.info(("The root path of backups for rollback: `%s`"):format(get_root_of_backup()))
+  report.info(("The root path of module-mapping: `%s`"):format(get_root_of_modmap()))
+  return report.info(("The root path of pool: `%s`"):format(get_root_of_pool()))
 end
 local function report_thyme_config()
-  report_start("Thyme .nvim-thyme.fnl")
+  report.start("Thyme .nvim-thyme.fnl")
   local config = get_config()
-  return report_info(("The current config:\n\n%s\n"):format(fennel.view(config)))
+  return report.info(("The current config:\n\n%s\n"):format(fennel.view(config)))
 end
 local function report_fennel_paths()
-  report_start("Thyme fennel.{path,macro-path}")
-  report_info(("fennel.path:\n- `%s`"):format(fennel.path:gsub(";", "`\n- `")))
-  return report_info(("fennel.macro-path:\n- `%s`"):format(fennel["macro-path"]:gsub(";", "`\n- `")))
+  report.start("Thyme fennel.{path,macro-path}")
+  report.info(("fennel.path:\n- `%s`"):format(fennel.path:gsub(";", "`\n- `")))
+  return report.info(("fennel.macro-path:\n- `%s`"):format(fennel["macro-path"]:gsub(";", "`\n- `")))
 end
 local function _12_()
   report_integrations()


### PR DESCRIPTION
to have `fennel-ls` reduce the errors: unused definition.