### PR TITLE
refactor(loader): substitute `string.find`

### DIFF
--- a/fnl/thyme/loader/runtime-module.fnl
+++ b/fnl/thyme/loader/runtime-module.fnl
@@ -93,7 +93,7 @@
 cache dir.
 @param module-name string
 @return string|function a lua chunk in function, or a string to tell why failed to load module."
-  (if (module-name:find "^vim%.")
+  (if (string.find module-name "^vim%.")
       ;; NOTE: This `vim` module detection is a workaround for not to be
       ;; a suspect of the errors missing such `vim` modules due to a build
       ;; failure in neovim development; otherwise, get into infinite loop.

--- a/lua/thyme/loader/runtime-module.lua
+++ b/lua/thyme/loader/runtime-module.lua
@@ -117,7 +117,7 @@ local function module_name__3efnl_file_on_rtp_21(module_name)
   return fennel["search-module"](module_name, fennel.path)
 end
 local function search_fnl_module_on_rtp_21(module_name, ...)
-  if module_name:find("^vim%.") then
+  if string.find(module_name, "^vim%.") then
     local path = vim.fs.joinpath(vim.env.VIMRUNTIME, "lua")
     return loadfile(path)
   elseif ("fennel" == module_name) then


### PR DESCRIPTION
to get more concise error message.