### PR TITLE
ci(test): pass `-Es` to `nvim` via `$VUSTED_EXTRA_ARGS`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run tests
         env:
           VUSTED_EXTRA_FLAGS: "--defer-print --suppress-pending"
-          VUSTED_EXTRA_ARGS: ""
+          VUSTED_EXTRA_ARGS: "-Es"
         run: |
           make -j build
           make test


### PR DESCRIPTION
in order to suppress interefering `:trust` confirmation messages.

Should close #105